### PR TITLE
[feat] 공통에러처리 및 회원가입, 로그인, 토큰재발급 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,11 +32,17 @@ dependencies {
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
     // spring security
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
     testImplementation 'org.springframework.security:spring-security-test'
+
+    // jwt
+    implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
+    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
+    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
 
     // spring cloud AWS S3
 //    implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.3.0'

--- a/build.gradle
+++ b/build.gradle
@@ -32,12 +32,14 @@ dependencies {
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
+    // spring security
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
+
     // spring cloud AWS S3
-    implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.3.0'
+//    implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.3.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/eightyage/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/eightyage/domain/auth/controller/AuthController.java
@@ -9,7 +9,6 @@ import com.example.eightyage.global.annotation.RefreshToken;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 

--- a/src/main/java/com/example/eightyage/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/eightyage/domain/auth/controller/AuthController.java
@@ -1,0 +1,48 @@
+package com.example.eightyage.domain.auth.controller;
+
+import com.example.eightyage.domain.auth.dto.request.AuthSignupRequestDto;
+import com.example.eightyage.domain.auth.dto.response.AuthAccessTokenResponseDto;
+import com.example.eightyage.domain.auth.dto.response.AuthTokensResponseDto;
+import com.example.eightyage.domain.auth.service.AuthService;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class AuthController {
+
+    private final AuthService authService;
+    private static final int REFRESH_TOKEN_TIME = 7 * 24 * 60 * 60; // 7주일
+
+    /* 회원가입 */
+    @PostMapping("/v1/auth/signup")
+    public AuthAccessTokenResponseDto signup(
+            @RequestBody AuthSignupRequestDto request,
+            HttpServletResponse httpServletResponse
+    ) {
+        AuthTokensResponseDto tokensResponseDto = authService.signup(request);
+
+        setRefreshTokenCookie(httpServletResponse, tokensResponseDto.getRefreshToken());
+
+        return new AuthAccessTokenResponseDto(tokensResponseDto.getAccessToken());
+    }
+
+    /* http only 사용하기 위해 쿠키에 refreshToken 저장 */
+    private void setRefreshTokenCookie(HttpServletResponse response, String refreshToken) {
+        Cookie cookie = new Cookie("refreshToken", refreshToken);
+        cookie.setMaxAge(REFRESH_TOKEN_TIME);
+        cookie.setSecure(true);
+        cookie.setHttpOnly(true);
+        cookie.setPath("/");
+
+        response.addCookie(cookie);
+    }
+
+
+}

--- a/src/main/java/com/example/eightyage/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/eightyage/domain/auth/controller/AuthController.java
@@ -5,6 +5,7 @@ import com.example.eightyage.domain.auth.dto.request.AuthSignupRequestDto;
 import com.example.eightyage.domain.auth.dto.response.AuthAccessTokenResponseDto;
 import com.example.eightyage.domain.auth.dto.response.AuthTokensResponseDto;
 import com.example.eightyage.domain.auth.service.AuthService;
+import com.example.eightyage.global.annotation.RefreshToken;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
@@ -40,6 +41,19 @@ public class AuthController {
             HttpServletResponse httpServletResponse
     ) {
         AuthTokensResponseDto tokensResponseDto = authService.signin(request);
+
+        setRefreshTokenCookie(httpServletResponse, tokensResponseDto.getRefreshToken());
+
+        return new AuthAccessTokenResponseDto(tokensResponseDto.getAccessToken());
+    }
+
+    /* 토큰 재발급 (로그인 기간 연장) */
+    @GetMapping("/v1/auth/refresh")
+    public AuthAccessTokenResponseDto refresh(
+            @RefreshToken String refreshToken,
+            HttpServletResponse httpServletResponse
+    ) {
+        AuthTokensResponseDto tokensResponseDto = authService.reissueAccessToken(refreshToken);
 
         setRefreshTokenCookie(httpServletResponse, tokensResponseDto.getRefreshToken());
 

--- a/src/main/java/com/example/eightyage/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/eightyage/domain/auth/controller/AuthController.java
@@ -1,16 +1,16 @@
 package com.example.eightyage.domain.auth.controller;
 
+import com.example.eightyage.domain.auth.dto.request.AuthSigninRequestDto;
 import com.example.eightyage.domain.auth.dto.request.AuthSignupRequestDto;
 import com.example.eightyage.domain.auth.dto.response.AuthAccessTokenResponseDto;
 import com.example.eightyage.domain.auth.dto.response.AuthTokensResponseDto;
 import com.example.eightyage.domain.auth.service.AuthService;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -23,10 +23,23 @@ public class AuthController {
     /* 회원가입 */
     @PostMapping("/v1/auth/signup")
     public AuthAccessTokenResponseDto signup(
-            @RequestBody AuthSignupRequestDto request,
+            @Valid @RequestBody AuthSignupRequestDto request,
             HttpServletResponse httpServletResponse
     ) {
         AuthTokensResponseDto tokensResponseDto = authService.signup(request);
+
+        setRefreshTokenCookie(httpServletResponse, tokensResponseDto.getRefreshToken());
+
+        return new AuthAccessTokenResponseDto(tokensResponseDto.getAccessToken());
+    }
+
+    /* 로그인 */
+    @PostMapping("/v1/auth/signin")
+    public AuthAccessTokenResponseDto signin(
+            @Valid @RequestBody AuthSigninRequestDto request,
+            HttpServletResponse httpServletResponse
+    ) {
+        AuthTokensResponseDto tokensResponseDto = authService.signin(request);
 
         setRefreshTokenCookie(httpServletResponse, tokensResponseDto.getRefreshToken());
 

--- a/src/main/java/com/example/eightyage/domain/auth/dto/request/AuthSigninRequestDto.java
+++ b/src/main/java/com/example/eightyage/domain/auth/dto/request/AuthSigninRequestDto.java
@@ -1,0 +1,11 @@
+package com.example.eightyage.domain.auth.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class AuthSigninRequestDto {
+
+    private String email;
+    private String password;
+
+}

--- a/src/main/java/com/example/eightyage/domain/auth/dto/request/AuthSignupRequestDto.java
+++ b/src/main/java/com/example/eightyage/domain/auth/dto/request/AuthSignupRequestDto.java
@@ -1,0 +1,24 @@
+package com.example.eightyage.domain.auth.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Getter;
+
+@Getter
+public class AuthSignupRequestDto {
+
+    @NotBlank(message = "이메일은 필수 입력 값입니다.")
+    @Email(message = "이메일 형식으로 입력되어야 합니다.")
+    private String email;
+
+    @NotBlank(message = "닉네임은 필수 입력 값입니다.")
+    private String nickname;
+
+    @NotBlank(message = "비밀번호는 필수 입력 값입니다.")
+    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{8,}$",
+            message = "비밀번호는 영어, 숫자 포함 8자리 이상이어야 합니다.")
+    private String password;
+
+    private String passwordCheck;
+}

--- a/src/main/java/com/example/eightyage/domain/auth/dto/response/AuthAccessTokenResponseDto.java
+++ b/src/main/java/com/example/eightyage/domain/auth/dto/response/AuthAccessTokenResponseDto.java
@@ -1,0 +1,12 @@
+package com.example.eightyage.domain.auth.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class AuthAccessTokenResponseDto {
+
+    private final String accessToken;
+
+}

--- a/src/main/java/com/example/eightyage/domain/auth/dto/response/AuthTokensResponseDto.java
+++ b/src/main/java/com/example/eightyage/domain/auth/dto/response/AuthTokensResponseDto.java
@@ -1,0 +1,13 @@
+package com.example.eightyage.domain.auth.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class AuthTokensResponseDto {
+
+    private final String AccessToken;
+    private final String refreshToken;
+
+}

--- a/src/main/java/com/example/eightyage/domain/auth/entity/RefreshToken.java
+++ b/src/main/java/com/example/eightyage/domain/auth/entity/RefreshToken.java
@@ -17,14 +17,14 @@ public class RefreshToken {
 
     private Long userId;
 
-    private String RefreshToken;
+    private String token;
 
     @Enumerated(EnumType.STRING)
     private TokenState tokenState;
 
     public RefreshToken(Long userId) {
         this.userId = userId;
-        this.RefreshToken = UUID.randomUUID().toString();
+        this.token = UUID.randomUUID().toString();
         this.tokenState = TokenState.VALID;
     }
 

--- a/src/main/java/com/example/eightyage/domain/auth/entity/RefreshToken.java
+++ b/src/main/java/com/example/eightyage/domain/auth/entity/RefreshToken.java
@@ -1,0 +1,34 @@
+package com.example.eightyage.domain.auth.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class RefreshToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long userId;
+
+    private String RefreshToken;
+
+    @Enumerated(EnumType.STRING)
+    private TokenState tokenState;
+
+    public RefreshToken(Long userId) {
+        this.userId = userId;
+        this.RefreshToken = UUID.randomUUID().toString();
+        this.tokenState = TokenState.VALID;
+    }
+
+    public void updateTokenStatus(TokenState tokenStatus){
+        this.tokenState = tokenStatus;
+    }
+}

--- a/src/main/java/com/example/eightyage/domain/auth/entity/TokenState.java
+++ b/src/main/java/com/example/eightyage/domain/auth/entity/TokenState.java
@@ -1,0 +1,6 @@
+package com.example.eightyage.domain.auth.entity;
+
+public enum TokenState {
+    VALID,
+    INVALIDATED
+}

--- a/src/main/java/com/example/eightyage/domain/auth/entity/User.java
+++ b/src/main/java/com/example/eightyage/domain/auth/entity/User.java
@@ -1,0 +1,27 @@
+package com.example.eightyage.domain.auth.entity;
+
+import com.example.eightyage.global.entity.TimeStamped;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor
+public class User extends TimeStamped {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true)
+    private String email;
+
+    private String nickname;
+
+    private String password;
+
+    @Enumerated(EnumType.STRING)
+    private UserRole userRole;
+
+}

--- a/src/main/java/com/example/eightyage/domain/auth/entity/UserRole.java
+++ b/src/main/java/com/example/eightyage/domain/auth/entity/UserRole.java
@@ -1,0 +1,29 @@
+package com.example.eightyage.domain.auth.entity;
+
+import com.example.eightyage.global.exception.UnauthorizedException;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Arrays;
+
+@Getter
+@RequiredArgsConstructor
+public enum UserRole {
+
+    ROLE_USER(Authority.USER),
+    ROLE_ADMIN(Authority.ADMIN);
+
+    private final String userRole;
+
+    public static UserRole of(String role) {
+        return Arrays.stream(UserRole.values())
+                .filter(r -> r.getUserRole().equalsIgnoreCase(role))
+                .findFirst()
+                .orElseThrow(() -> new UnauthorizedException("유효하지 않은 UserRole"));
+    }
+
+    public static class Authority {
+        public static final String USER = "ROLE_USER";
+        public static final String ADMIN = "ROLE_ADMIN";
+    }
+}

--- a/src/main/java/com/example/eightyage/domain/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/example/eightyage/domain/auth/repository/RefreshTokenRepository.java
@@ -3,5 +3,8 @@ package com.example.eightyage.domain.auth.repository;
 import com.example.eightyage.domain.auth.entity.RefreshToken;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long>{
+    Optional<RefreshToken> findByRefreshToken(String token);
 }

--- a/src/main/java/com/example/eightyage/domain/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/example/eightyage/domain/auth/repository/RefreshTokenRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long>{
-    Optional<RefreshToken> findByRefreshToken(String token);
+    Optional<RefreshToken> findByToken(String token);
 }

--- a/src/main/java/com/example/eightyage/domain/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/example/eightyage/domain/auth/repository/RefreshTokenRepository.java
@@ -1,0 +1,7 @@
+package com.example.eightyage.domain.auth.repository;
+
+import com.example.eightyage.domain.auth.entity.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long>{
+}

--- a/src/main/java/com/example/eightyage/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/eightyage/domain/auth/service/AuthService.java
@@ -2,7 +2,6 @@ package com.example.eightyage.domain.auth.service;
 
 import com.example.eightyage.domain.auth.dto.request.AuthSigninRequestDto;
 import com.example.eightyage.domain.auth.dto.request.AuthSignupRequestDto;
-import com.example.eightyage.domain.auth.dto.response.AuthAccessTokenResponseDto;
 import com.example.eightyage.domain.auth.dto.response.AuthTokensResponseDto;
 import com.example.eightyage.domain.user.entity.User;
 import com.example.eightyage.domain.user.service.UserService;

--- a/src/main/java/com/example/eightyage/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/eightyage/domain/auth/service/AuthService.java
@@ -1,0 +1,33 @@
+package com.example.eightyage.domain.auth.service;
+
+import com.example.eightyage.domain.auth.dto.request.AuthSignupRequestDto;
+import com.example.eightyage.domain.auth.dto.response.AuthAccessTokenResponseDto;
+import com.example.eightyage.domain.auth.dto.response.AuthTokensResponseDto;
+import com.example.eightyage.domain.user.entity.User;
+import com.example.eightyage.domain.user.service.UserService;
+import com.example.eightyage.global.exception.BadRequestException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final UserService userService;
+    private final TokenService tokenService;
+
+    /* 회원가입 */
+    public AuthTokensResponseDto signup(AuthSignupRequestDto request) {
+
+        if (!request.getPassword().equals(request.getPasswordCheck())) {
+            throw new BadRequestException("비밀번호 확인을 입력해주세요");
+        }
+
+        User user = userService.saveUser(request.getEmail(), request.getNickname(), request.getPassword());
+
+        String accessToken = tokenService.createAccessToken(user);
+        String refreshToken = tokenService.createRefreshToken(user);
+
+        return new AuthTokensResponseDto(accessToken, refreshToken);
+    }
+}

--- a/src/main/java/com/example/eightyage/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/eightyage/domain/auth/service/AuthService.java
@@ -45,6 +45,14 @@ public class AuthService {
         return getTokenResponse(user);
     }
 
+    /* Access Token, Refresh Token 재발급 */
+    @Transactional
+    public AuthTokensResponseDto reissueAccessToken(String refreshToken) {
+        User user = tokenService.reissueToken(refreshToken);
+
+        return getTokenResponse(user);
+    }
+
     /* Access Token, Refresh Token 생성 및 저장 */
     private AuthTokensResponseDto getTokenResponse(User user) {
 

--- a/src/main/java/com/example/eightyage/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/eightyage/domain/auth/service/AuthService.java
@@ -1,13 +1,17 @@
 package com.example.eightyage.domain.auth.service;
 
+import com.example.eightyage.domain.auth.dto.request.AuthSigninRequestDto;
 import com.example.eightyage.domain.auth.dto.request.AuthSignupRequestDto;
 import com.example.eightyage.domain.auth.dto.response.AuthAccessTokenResponseDto;
 import com.example.eightyage.domain.auth.dto.response.AuthTokensResponseDto;
 import com.example.eightyage.domain.user.entity.User;
 import com.example.eightyage.domain.user.service.UserService;
 import com.example.eightyage.global.exception.BadRequestException;
+import com.example.eightyage.global.exception.UnauthorizedException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -15,6 +19,7 @@ public class AuthService {
 
     private final UserService userService;
     private final TokenService tokenService;
+    private final PasswordEncoder passwordEncoder;
 
     /* 회원가입 */
     public AuthTokensResponseDto signup(AuthSignupRequestDto request) {
@@ -24,6 +29,24 @@ public class AuthService {
         }
 
         User user = userService.saveUser(request.getEmail(), request.getNickname(), request.getPassword());
+
+        return getTokenResponse(user);
+    }
+
+    /* 로그인 */
+    @Transactional
+    public AuthTokensResponseDto signin(AuthSigninRequestDto request) {
+        User user = userService.findUserByEmailOrElseThrow(request.getEmail());
+
+        if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
+            throw new UnauthorizedException("잘못된 비밀번호입니다.");
+        }
+
+        return getTokenResponse(user);
+    }
+
+    /* Access Token, Refresh Token 생성 및 저장 */
+    private AuthTokensResponseDto getTokenResponse(User user) {
 
         String accessToken = tokenService.createAccessToken(user);
         String refreshToken = tokenService.createRefreshToken(user);

--- a/src/main/java/com/example/eightyage/domain/auth/service/TokenService.java
+++ b/src/main/java/com/example/eightyage/domain/auth/service/TokenService.java
@@ -4,7 +4,7 @@ import com.example.eightyage.domain.auth.entity.RefreshToken;
 import com.example.eightyage.domain.auth.repository.RefreshTokenRepository;
 import com.example.eightyage.domain.user.entity.User;
 import com.example.eightyage.domain.user.service.UserService;
-import com.example.eightyage.global.config.JwtUtil;
+import com.example.eightyage.global.util.JwtUtil;
 import com.example.eightyage.global.exception.NotFoundException;
 import com.example.eightyage.global.exception.UnauthorizedException;
 import lombok.RequiredArgsConstructor;
@@ -28,7 +28,7 @@ public class TokenService {
     /* Refresh Token 생성 */
     public String createRefreshToken(User user) {
         RefreshToken refreshToken = refreshTokenRepository.save(new RefreshToken(user.getId()));
-        return refreshToken.getRefreshToken();
+        return refreshToken.getToken();
     }
 
     /* Refresh Token 유효성 검사 */
@@ -45,7 +45,7 @@ public class TokenService {
     }
 
     private RefreshToken findByTokenOrElseThrow(String token) {
-        return refreshTokenRepository.findByRefreshToken(token).orElseThrow(
+        return refreshTokenRepository.findByToken(token).orElseThrow(
                 () -> new NotFoundException("리프레시 토큰을 찾을 수 없습니다."));
     }
 }

--- a/src/main/java/com/example/eightyage/domain/auth/service/TokenService.java
+++ b/src/main/java/com/example/eightyage/domain/auth/service/TokenService.java
@@ -5,6 +5,7 @@ import com.example.eightyage.domain.auth.repository.RefreshTokenRepository;
 import com.example.eightyage.domain.user.entity.User;
 import com.example.eightyage.domain.user.service.UserService;
 import com.example.eightyage.global.config.JwtUtil;
+import com.example.eightyage.global.exception.NotFoundException;
 import com.example.eightyage.global.exception.UnauthorizedException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -30,32 +31,21 @@ public class TokenService {
         return refreshToken.getRefreshToken();
     }
 
-//    /* Refresh Token 만료 */
-//    public void revokeRefreshToken(Long userId) {
-//        RefreshToken refreshToken = findRefreshTokenById(userId);
-//        refreshToken.updateTokenStatus(INVALIDATED);
-//    }
-//
-//    /* Refresh Token 유효성 검사 */
-//    public User reissueToken(String token) {
-//
-//        RefreshToken refreshToken = findByTokenOrElseThrow(token);
-//
-//        if (refreshToken.getTokenState() == INVALIDATED) {
-//            throw new UnauthorizedException("사용이 만료된 refresh token 입니다.");
-//        }
-//        refreshToken.updateTokenStatus(INVALIDATED);
-//
-//        return userService.findUserByIdOrElseThrow(refreshToken.getUserId());
-//    }
-//
-//    private RefreshToken findByTokenOrElseThrow(String token) {
-//        return refreshTokenRepository.findByToken(token).orElseThrow(
-//                () -> new NotFoundException("Not Found Token"));
-//    }
-//
-//    private RefreshToken findRefreshTokenById(Long userId) {
-//        return refreshTokenRepository.findById(userId).orElseThrow(
-//                () -> new NotFoundException("Not Found Token"));
-//    }
+    /* Refresh Token 유효성 검사 */
+    public User reissueToken(String token) {
+
+        RefreshToken refreshToken = findByTokenOrElseThrow(token);
+
+        if (refreshToken.getTokenState() == INVALIDATED) {
+            throw new UnauthorizedException("사용이 만료된 refresh token 입니다.");
+        }
+        refreshToken.updateTokenStatus(INVALIDATED);
+
+        return userService.findUserByIdOrElseThrow(refreshToken.getUserId());
+    }
+
+    private RefreshToken findByTokenOrElseThrow(String token) {
+        return refreshTokenRepository.findByRefreshToken(token).orElseThrow(
+                () -> new NotFoundException("리프레시 토큰을 찾을 수 없습니다."));
+    }
 }

--- a/src/main/java/com/example/eightyage/domain/auth/service/TokenService.java
+++ b/src/main/java/com/example/eightyage/domain/auth/service/TokenService.java
@@ -1,0 +1,61 @@
+package com.example.eightyage.domain.auth.service;
+
+import com.example.eightyage.domain.auth.entity.RefreshToken;
+import com.example.eightyage.domain.auth.repository.RefreshTokenRepository;
+import com.example.eightyage.domain.user.entity.User;
+import com.example.eightyage.domain.user.service.UserService;
+import com.example.eightyage.global.config.JwtUtil;
+import com.example.eightyage.global.exception.UnauthorizedException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import static com.example.eightyage.domain.auth.entity.TokenState.INVALIDATED;
+
+@Service
+@RequiredArgsConstructor
+public class TokenService {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final UserService userService;
+    private final JwtUtil jwtUtil;
+
+    /* Access Token 생성 */
+    public String createAccessToken(User user) {
+        return jwtUtil.createAccessToken(user.getId(), user.getEmail(), user.getNickname(), user.getUserRole());
+    }
+
+    /* Refresh Token 생성 */
+    public String createRefreshToken(User user) {
+        RefreshToken refreshToken = refreshTokenRepository.save(new RefreshToken(user.getId()));
+        return refreshToken.getRefreshToken();
+    }
+
+//    /* Refresh Token 만료 */
+//    public void revokeRefreshToken(Long userId) {
+//        RefreshToken refreshToken = findRefreshTokenById(userId);
+//        refreshToken.updateTokenStatus(INVALIDATED);
+//    }
+//
+//    /* Refresh Token 유효성 검사 */
+//    public User reissueToken(String token) {
+//
+//        RefreshToken refreshToken = findByTokenOrElseThrow(token);
+//
+//        if (refreshToken.getTokenState() == INVALIDATED) {
+//            throw new UnauthorizedException("사용이 만료된 refresh token 입니다.");
+//        }
+//        refreshToken.updateTokenStatus(INVALIDATED);
+//
+//        return userService.findUserByIdOrElseThrow(refreshToken.getUserId());
+//    }
+//
+//    private RefreshToken findByTokenOrElseThrow(String token) {
+//        return refreshTokenRepository.findByToken(token).orElseThrow(
+//                () -> new NotFoundException("Not Found Token"));
+//    }
+//
+//    private RefreshToken findRefreshTokenById(Long userId) {
+//        return refreshTokenRepository.findById(userId).orElseThrow(
+//                () -> new NotFoundException("Not Found Token"));
+//    }
+}

--- a/src/main/java/com/example/eightyage/domain/user/entity/User.java
+++ b/src/main/java/com/example/eightyage/domain/user/entity/User.java
@@ -1,4 +1,4 @@
-package com.example.eightyage.domain.auth.entity;
+package com.example.eightyage.domain.user.entity;
 
 import com.example.eightyage.global.entity.TimeStamped;
 import jakarta.persistence.*;
@@ -24,4 +24,10 @@ public class User extends TimeStamped {
     @Enumerated(EnumType.STRING)
     private UserRole userRole;
 
+    public User(String email, String nickname, String password) {
+        this.email = email;
+        this.nickname = nickname;
+        this.password = password;
+        this.userRole = UserRole.ROLE_USER;
+    }
 }

--- a/src/main/java/com/example/eightyage/domain/user/entity/UserRole.java
+++ b/src/main/java/com/example/eightyage/domain/user/entity/UserRole.java
@@ -1,4 +1,4 @@
-package com.example.eightyage.domain.auth.entity;
+package com.example.eightyage.domain.user.entity;
 
 import com.example.eightyage.global.exception.UnauthorizedException;
 import lombok.Getter;

--- a/src/main/java/com/example/eightyage/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/eightyage/domain/user/repository/UserRepository.java
@@ -1,0 +1,8 @@
+package com.example.eightyage.domain.user.repository;
+
+import com.example.eightyage.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    boolean existsByEmail(String email);
+}

--- a/src/main/java/com/example/eightyage/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/eightyage/domain/user/repository/UserRepository.java
@@ -3,6 +3,10 @@ package com.example.eightyage.domain.user.repository;
 import com.example.eightyage.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByEmail(String email);
+
+    Optional<User> findByEmail(String email);
 }

--- a/src/main/java/com/example/eightyage/domain/user/service/UserService.java
+++ b/src/main/java/com/example/eightyage/domain/user/service/UserService.java
@@ -3,6 +3,7 @@ package com.example.eightyage.domain.user.service;
 import com.example.eightyage.domain.user.entity.User;
 import com.example.eightyage.domain.user.repository.UserRepository;
 import com.example.eightyage.global.exception.BadRequestException;
+import com.example.eightyage.global.exception.UnauthorizedException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -25,5 +26,11 @@ public class UserService {
         User user = new User(email, nickname, encodedPassword);
 
         return userRepository.save(user);
+    }
+
+    public User findUserByEmailOrElseThrow(String email) {
+        return userRepository.findByEmail(email).orElseThrow(
+                () -> new UnauthorizedException("가입한 유저의 이메일이 아닙니다.")
+        );
     }
 }

--- a/src/main/java/com/example/eightyage/domain/user/service/UserService.java
+++ b/src/main/java/com/example/eightyage/domain/user/service/UserService.java
@@ -3,6 +3,7 @@ package com.example.eightyage.domain.user.service;
 import com.example.eightyage.domain.user.entity.User;
 import com.example.eightyage.domain.user.repository.UserRepository;
 import com.example.eightyage.global.exception.BadRequestException;
+import com.example.eightyage.global.exception.NotFoundException;
 import com.example.eightyage.global.exception.UnauthorizedException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -31,6 +32,12 @@ public class UserService {
     public User findUserByEmailOrElseThrow(String email) {
         return userRepository.findByEmail(email).orElseThrow(
                 () -> new UnauthorizedException("가입한 유저의 이메일이 아닙니다.")
+        );
+    }
+
+    public User findUserByIdOrElseThrow(Long userId) {
+        return userRepository.findById(userId).orElseThrow(
+                () -> new NotFoundException("해당 유저의 Id를 찾을 수 없습니다.")
         );
     }
 }

--- a/src/main/java/com/example/eightyage/domain/user/service/UserService.java
+++ b/src/main/java/com/example/eightyage/domain/user/service/UserService.java
@@ -1,0 +1,29 @@
+package com.example.eightyage.domain.user.service;
+
+import com.example.eightyage.domain.user.entity.User;
+import com.example.eightyage.domain.user.repository.UserRepository;
+import com.example.eightyage.global.exception.BadRequestException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public User saveUser(String email, String nickname, String password) {
+
+        if (userRepository.existsByEmail(email)) {
+            throw new BadRequestException("등록된 이메일입니다.");
+        }
+
+        String encodedPassword = passwordEncoder.encode(password);
+
+        User user = new User(email, nickname, encodedPassword);
+
+        return userRepository.save(user);
+    }
+}

--- a/src/main/java/com/example/eightyage/global/annotation/RefreshToken.java
+++ b/src/main/java/com/example/eightyage/global/annotation/RefreshToken.java
@@ -1,0 +1,11 @@
+package com.example.eightyage.global.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface RefreshToken {
+}

--- a/src/main/java/com/example/eightyage/global/argument/RefreshArgumentResolver.java
+++ b/src/main/java/com/example/eightyage/global/argument/RefreshArgumentResolver.java
@@ -1,0 +1,44 @@
+package com.example.eightyage.global.argument;
+
+import com.example.eightyage.global.annotation.RefreshToken;
+import com.example.eightyage.global.exception.UnauthorizedException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+public class RefreshArgumentResolver implements HandlerMethodArgumentResolver {
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        boolean hasRefreshTokenAnnotation = parameter.getParameterAnnotation(RefreshToken.class) != null;
+        boolean isStringType = parameter.getParameterType().equals(String.class);
+
+        if (hasRefreshTokenAnnotation != isStringType) {
+            throw new UnauthorizedException("@RefreshToken과 String 타입은 함께 사용되어야 합니다.");
+        }
+        return hasRefreshTokenAnnotation;
+    }
+
+    @Override
+    public Object resolveArgument(
+            MethodParameter parameter,
+            ModelAndViewContainer mavContainer,
+            NativeWebRequest webRequest,
+            WebDataBinderFactory binderFactory
+    ) {
+        HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
+
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if ("refreshToken".equals(cookie.getName())) {
+                    return cookie.getValue();
+                }
+            }
+        }
+        throw new UnauthorizedException("리프레시 토큰이 존재하지 않습니다. 다시 로그인 해주세요.");
+    }
+}

--- a/src/main/java/com/example/eightyage/global/config/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/eightyage/global/config/JwtAuthenticationFilter.java
@@ -1,6 +1,6 @@
 package com.example.eightyage.global.config;
 
-import com.example.eightyage.domain.auth.entity.UserRole;
+import com.example.eightyage.domain.user.entity.UserRole;
 import com.example.eightyage.global.dto.AuthUser;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;

--- a/src/main/java/com/example/eightyage/global/config/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/eightyage/global/config/JwtAuthenticationFilter.java
@@ -1,0 +1,78 @@
+package com.example.eightyage.global.config;
+
+import com.example.eightyage.domain.auth.entity.UserRole;
+import com.example.eightyage.global.dto.AuthUser;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtUtil jwtUtil;
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            @NonNull HttpServletResponse response,
+            @NonNull FilterChain filterChain) throws ServletException, IOException {
+
+        String authorizationHeader = request.getHeader("Authorization");
+
+        if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
+            String jwt = jwtUtil.substringToken(authorizationHeader);
+
+            try {
+                Claims claims = jwtUtil.extractClaims(jwt);
+
+                if (SecurityContextHolder.getContext().getAuthentication() == null) {
+                    setAuthentication(claims);
+                }
+
+            } catch (SecurityException | MalformedJwtException e) {
+                log.error("Invalid JWT signature, 유효하지 않는 JWT 서명 입니다.", e);
+                response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "유효하지 않는 JWT 서명입니다.");
+                return;
+            } catch (ExpiredJwtException e) {
+                log.error("Expired JWT token, 만료된 JWT token 입니다.", e);
+                response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "만료된 JWT 토큰입니다.");
+                return;
+            } catch (UnsupportedJwtException e) {
+                log.error("Unsupported JWT token, 지원되지 않는 JWT 토큰 입니다.", e);
+                response.sendError(HttpServletResponse.SC_BAD_REQUEST, "지원되지 않는 JWT 토큰입니다.");
+                return;
+            } catch (Exception e) {
+                log.error("Internal server error", e);
+                response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+                return;
+            }
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    private void setAuthentication(Claims claims) {
+        Long userId = Long.valueOf(claims.getSubject());
+        String email = claims.get("email", String.class);
+        String nickname = claims.get("nickname", String.class);
+        UserRole userRole = UserRole.of(claims.get("userRole", String.class));
+
+        AuthUser authUser = new AuthUser(userId, email, nickname, userRole);
+        JwtAuthenticationToken authenticationToken = new JwtAuthenticationToken(authUser);
+        SecurityContextHolder.getContext().setAuthentication(authenticationToken);
+    }
+}

--- a/src/main/java/com/example/eightyage/global/config/JwtAuthenticationToken.java
+++ b/src/main/java/com/example/eightyage/global/config/JwtAuthenticationToken.java
@@ -1,0 +1,25 @@
+package com.example.eightyage.global.config;
+
+import com.example.eightyage.global.dto.AuthUser;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+
+public class JwtAuthenticationToken extends AbstractAuthenticationToken {
+
+    private final AuthUser authUser;
+
+    public JwtAuthenticationToken(AuthUser authUser) {
+        super(authUser.getAuthorities());
+        this.authUser = authUser;
+        setAuthenticated(true);
+    }
+
+    @Override
+    public Object getCredentials() {
+        return null;
+    }
+
+    @Override
+    public Object getPrincipal() {
+        return authUser;
+    }
+}

--- a/src/main/java/com/example/eightyage/global/config/JwtUtil.java
+++ b/src/main/java/com/example/eightyage/global/config/JwtUtil.java
@@ -4,7 +4,7 @@ import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
-import com.example.eightyage.domain.auth.entity.UserRole;
+import com.example.eightyage.domain.user.entity.UserRole;
 import jakarta.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -34,7 +34,7 @@ public class JwtUtil {
         key = Keys.hmacShaKeyFor(bytes);
     }
 
-    public String createToken(Long userId, String email, String nickname, UserRole userRole) {
+    public String createAccessToken(Long userId, String email, String nickname, UserRole userRole) {
         Date date = new Date();
 
         return BEARER_PREFIX +

--- a/src/main/java/com/example/eightyage/global/config/JwtUtil.java
+++ b/src/main/java/com/example/eightyage/global/config/JwtUtil.java
@@ -1,0 +1,67 @@
+package com.example.eightyage.global.config;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import com.example.eightyage.domain.auth.entity.UserRole;
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.rmi.ServerException;
+import java.security.Key;
+import java.util.Base64;
+import java.util.Date;
+
+@Slf4j(topic = "JwtUtil")
+@Component
+public class JwtUtil {
+
+    private static final String BEARER_PREFIX = "Bearer ";
+    private static final long ACCESS_TOKEN_TIME = 10 * 60 * 1000L; // 10분
+
+    @Value("${jwt.secret.key}")
+    private String secretKey;
+    private Key key;
+    private final SignatureAlgorithm signatureAlgorithm = SignatureAlgorithm.HS256;
+
+    @PostConstruct
+    public void init() {
+        byte[] bytes = Base64.getDecoder().decode(secretKey);
+        key = Keys.hmacShaKeyFor(bytes);
+    }
+
+    public String createToken(Long userId, String email, String nickname, UserRole userRole) {
+        Date date = new Date();
+
+        return BEARER_PREFIX +
+                Jwts.builder()
+                        .setSubject(String.valueOf(userId))
+                        .claim("email", email)
+                        .claim("nickname", nickname)
+                        .claim("userRole", userRole)
+                        .setExpiration(new Date(date.getTime() + ACCESS_TOKEN_TIME))
+                        .setIssuedAt(date)
+                        .signWith(key, signatureAlgorithm)
+                        .compact();
+    }
+
+    public String substringToken(String tokenValue) throws ServerException {
+        if (StringUtils.hasText(tokenValue) && tokenValue.startsWith(BEARER_PREFIX)) {
+            return tokenValue.substring(7);
+        }
+        throw new ServerException("Not Found Token");
+    }
+
+    public Claims extractClaims(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+}
+

--- a/src/main/java/com/example/eightyage/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/eightyage/global/config/SecurityConfig.java
@@ -40,7 +40,7 @@ public class SecurityConfig {
                 .logout(AbstractHttpConfigurer::disable)
                 .rememberMe(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
-                                .requestMatchers(request -> request.getRequestURI().startsWith("/auth")).permitAll()
+                                .requestMatchers(request -> request.getRequestURI().startsWith("/api/v1/auth")).permitAll()
                                 .anyRequest().authenticated()
                 )
                 .build();

--- a/src/main/java/com/example/eightyage/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/eightyage/global/config/SecurityConfig.java
@@ -1,0 +1,48 @@
+package com.example.eightyage.global.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.servletapi.SecurityContextHolderAwareRequestFilter;
+
+@Configuration
+@RequiredArgsConstructor
+@EnableWebSecurity
+@EnableMethodSecurity(securedEnabled = true)
+public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        return http
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(session -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                )
+                .addFilterBefore(jwtAuthenticationFilter, SecurityContextHolderAwareRequestFilter.class)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .anonymous(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .logout(AbstractHttpConfigurer::disable)
+                .rememberMe(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(auth -> auth
+                                .requestMatchers(request -> request.getRequestURI().startsWith("/auth")).permitAll()
+                                .anyRequest().authenticated()
+                )
+                .build();
+    }
+}

--- a/src/main/java/com/example/eightyage/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/eightyage/global/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.example.eightyage.global.config;
 
+import com.example.eightyage.global.filter.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/com/example/eightyage/global/config/WebConfig.java
+++ b/src/main/java/com/example/eightyage/global/config/WebConfig.java
@@ -1,0 +1,18 @@
+package com.example.eightyage.global.config;
+
+import com.example.eightyage.global.argument.RefreshArgumentResolver;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    /* ArgumentResolver 등록 */
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(new RefreshArgumentResolver());
+    }
+}

--- a/src/main/java/com/example/eightyage/global/dto/AuthUser.java
+++ b/src/main/java/com/example/eightyage/global/dto/AuthUser.java
@@ -1,6 +1,6 @@
 package com.example.eightyage.global.dto;
 
-import com.example.eightyage.domain.auth.entity.UserRole;
+import com.example.eightyage.domain.user.entity.UserRole;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.security.core.GrantedAuthority;

--- a/src/main/java/com/example/eightyage/global/dto/AuthUser.java
+++ b/src/main/java/com/example/eightyage/global/dto/AuthUser.java
@@ -1,0 +1,27 @@
+package com.example.eightyage.global.dto;
+
+import com.example.eightyage.domain.auth.entity.UserRole;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import java.util.Collection;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class AuthUser {
+
+    private final Long userId;
+    private final String email;
+    private final String nickname;
+    private final Collection<? extends GrantedAuthority> authorities;
+
+    public AuthUser(Long userId, String email, String nickname, UserRole role) {
+        this.userId = userId;
+        this.email = email;
+        this.nickname = nickname;
+        this.authorities = List.of(new SimpleGrantedAuthority(role.name()));
+    }
+}

--- a/src/main/java/com/example/eightyage/global/entity/ErrorResponse.java
+++ b/src/main/java/com/example/eightyage/global/entity/ErrorResponse.java
@@ -3,6 +3,7 @@ package com.example.eightyage.global.entity;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.springframework.http.HttpStatus;
 
 @Getter
 @Setter
@@ -15,9 +16,13 @@ public class ErrorResponse {
 
     private String message;
 
-    public ErrorResponse(String statusName, Integer code, String message) {
-        this.status = statusName;
-        this.code = code;
+    public ErrorResponse(HttpStatus httpStatus, String message) {
+        this.status = httpStatus.name();
+        this.code = httpStatus.value();
         this.message = message;
+    }
+
+    public static ErrorResponse of(HttpStatus httpStatus, String message) {
+        return new ErrorResponse(httpStatus, message);
     }
 }

--- a/src/main/java/com/example/eightyage/global/entity/ErrorResponse.java
+++ b/src/main/java/com/example/eightyage/global/entity/ErrorResponse.java
@@ -8,21 +8,21 @@ import org.springframework.http.HttpStatus;
 @Getter
 @Setter
 @NoArgsConstructor
-public class ErrorResponse {
+public class ErrorResponse<T> {
 
     private String status;
 
     private Integer code;
 
-    private String message;
+    private T message;
 
-    public ErrorResponse(HttpStatus httpStatus, String message) {
+    public ErrorResponse(HttpStatus httpStatus, T message) {
         this.status = httpStatus.name();
         this.code = httpStatus.value();
         this.message = message;
     }
 
-    public static ErrorResponse of(HttpStatus httpStatus, String message) {
-        return new ErrorResponse(httpStatus, message);
+    public static <T> ErrorResponse<T> of(HttpStatus httpStatus, T message) {
+        return new ErrorResponse<>(httpStatus, message);
     }
 }

--- a/src/main/java/com/example/eightyage/global/exception/BadRequestException.java
+++ b/src/main/java/com/example/eightyage/global/exception/BadRequestException.java
@@ -1,0 +1,12 @@
+package com.example.eightyage.global.exception;
+
+public class BadRequestException extends CustomException {
+
+    public BadRequestException() {
+        super(ErrorCode.BAD_REQUEST);
+    }
+
+    public BadRequestException(String message) {
+        super(ErrorCode.BAD_REQUEST, message);
+    }
+}

--- a/src/main/java/com/example/eightyage/global/exception/CustomException.java
+++ b/src/main/java/com/example/eightyage/global/exception/CustomException.java
@@ -1,0 +1,25 @@
+package com.example.eightyage.global.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class CustomException extends RuntimeException {
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    // 예외 던질시 기본 메세지 출력
+    public CustomException(ErrorCode errorCode) {
+        super(errorCode.getDefaultMessage());
+        this.httpStatus = errorCode.getStatus();
+        this.message = errorCode.getDefaultMessage();
+    }
+
+    // 예외 던질시 메세지 출력
+    public CustomException(ErrorCode errorCode, String message) {
+        super(message);
+        this.httpStatus = errorCode.getStatus();
+        this.message = message;
+    }
+}

--- a/src/main/java/com/example/eightyage/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/eightyage/global/exception/ErrorCode.java
@@ -1,0 +1,20 @@
+package com.example.eightyage.global.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ErrorCode {
+    AUTHORIZATION(HttpStatus.UNAUTHORIZED, "인증이 필요합니다."),
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "찾지 못했습니다."),
+    FORBIDDEN(HttpStatus.FORBIDDEN, "권한이 없습니다.");
+
+    private final HttpStatus status;
+    private final String defaultMessage;
+
+    ErrorCode(HttpStatus status, String defaultMessage) {
+        this.status = status;
+        this.defaultMessage = defaultMessage;
+    }
+}

--- a/src/main/java/com/example/eightyage/global/exception/ForbiddenException.java
+++ b/src/main/java/com/example/eightyage/global/exception/ForbiddenException.java
@@ -1,0 +1,12 @@
+package com.example.eightyage.global.exception;
+
+public class ForbiddenException extends CustomException {
+
+    public ForbiddenException() {
+        super(ErrorCode.FORBIDDEN);
+    }
+
+    public ForbiddenException(String message) {
+        super(ErrorCode.FORBIDDEN,message);
+    }
+}

--- a/src/main/java/com/example/eightyage/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/eightyage/global/exception/GlobalExceptionHandler.java
@@ -1,16 +1,38 @@
 package com.example.eightyage.global.exception;
 
 import com.example.eightyage.global.entity.ErrorResponse;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import java.util.List;
+
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(CustomException.class)
-    public ErrorResponse invalidRequestExceptionException(CustomException ex) {
+    public ErrorResponse<String> invalidRequestExceptionException(CustomException ex) {
         HttpStatus httpStatus = ex.getHttpStatus();
         return ErrorResponse.of(httpStatus, ex.getMessage());
+    }
+
+    @ExceptionHandler
+    public ErrorResponse<List<String>> handleValidationException(MethodArgumentNotValidException e) {
+        List<FieldError> fieldErrors = e.getBindingResult().getFieldErrors();
+
+        List<String> validFailedList = fieldErrors.stream()
+                .map(error -> error.getField() + ": " + error.getDefaultMessage())
+                .toList();
+        return ErrorResponse.of(HttpStatus.BAD_REQUEST, validFailedList);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ErrorResponse<String> handleGlobalException(Exception e) {
+        log.error("Exception : {}",e.getMessage(),  e);
+        return ErrorResponse.of(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류가 발생했습니다.");
     }
 }

--- a/src/main/java/com/example/eightyage/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/eightyage/global/exception/GlobalExceptionHandler.java
@@ -1,18 +1,16 @@
 package com.example.eightyage.global.exception;
 
+import com.example.eightyage.global.entity.ErrorResponse;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
-
-import java.util.Map;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-    @ExceptionHandler(InvalidRequestException.class)
-    public ResponseEntity<Map<String, Object>> invalidRequestExceptionException(InvalidRequestException ex) {
-        HttpStatus status = HttpStatus.BAD_REQUEST;
-        return getErrorResponse(status, ex.getMessage());
+    @ExceptionHandler(CustomException.class)
+    public ErrorResponse invalidRequestExceptionException(CustomException ex) {
+        HttpStatus httpStatus = ex.getHttpStatus();
+        return ErrorResponse.of(httpStatus, ex.getMessage());
     }
 }

--- a/src/main/java/com/example/eightyage/global/exception/NotFoundException.java
+++ b/src/main/java/com/example/eightyage/global/exception/NotFoundException.java
@@ -1,0 +1,12 @@
+package com.example.eightyage.global.exception;
+
+public class NotFoundException extends CustomException {
+    public NotFoundException() {
+        super(ErrorCode.NOT_FOUND);
+    }
+
+    public NotFoundException(String message) {
+        super(ErrorCode.NOT_FOUND, message);
+    }
+}
+

--- a/src/main/java/com/example/eightyage/global/exception/UnauthorizedException.java
+++ b/src/main/java/com/example/eightyage/global/exception/UnauthorizedException.java
@@ -1,0 +1,11 @@
+package com.example.eightyage.global.exception;
+
+public class UnauthorizedException extends CustomException {
+
+  public UnauthorizedException() {
+    super(ErrorCode.AUTHORIZATION);
+  }
+  public UnauthorizedException(String message) {
+    super(ErrorCode.AUTHORIZATION, message);
+  }
+}

--- a/src/main/java/com/example/eightyage/global/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/eightyage/global/filter/JwtAuthenticationFilter.java
@@ -1,6 +1,8 @@
-package com.example.eightyage.global.config;
+package com.example.eightyage.global.filter;
 
 import com.example.eightyage.domain.user.entity.UserRole;
+import com.example.eightyage.global.config.JwtAuthenticationToken;
+import com.example.eightyage.global.util.JwtUtil;
 import com.example.eightyage.global.dto.AuthUser;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;

--- a/src/main/java/com/example/eightyage/global/util/JwtUtil.java
+++ b/src/main/java/com/example/eightyage/global/util/JwtUtil.java
@@ -1,4 +1,4 @@
-package com.example.eightyage.global.config;
+package com.example.eightyage.global.util;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,4 +30,5 @@ spring:
         dialect: org.hibernate.dialect.MySQLDialect
 
 jwt:
-  secret: ${JWT_SECRET_KEY}
+  secret:
+    key: ${JWT_SECRET_KEY}


### PR DESCRIPTION
## 🔗 Issue Number
close #1 
close #2 

## 📝 작업 내역
- [X] 공통에러처리
- [X] 회원가입
- [X] 로그인
- [X] 토큰 재발급


## 💡 PR 특이사항

### 참고사항
- CustomException과 각 에러 코드에 관한 예외클래스(CustomException을 상속)
- CustomException에는 HttpStatus와 메세지 정보를 가지고 있음
- ErrorCode Enum 자료형을 이용하여 에러 코드와 메세지를 관리할 수 있도록 정의
- build.gradle
  - aws S3 의존성을 추가하고 아무 설정을 해주지 않으면 에러발생 -> 주석처리
  - 추후 S3를 사용할 때 주석해제하여 사용할 것
  - spring security에 관한 의존성은 바로 확인 가능하도록 수정

### 의논할 것
- 유저가 ADMIN으로 가입하는 것을 방지하기 위해 request에 유저 ROLE기입을 하지 않음
- 가입할 때 자동으로 USER 권한으로만 가입
- ADMIM 권한으로 가입하고 싶은 경우 따로 INSERT 쿼리를 작성하거나 어드민 가입 api를 따로 팔 것
- user Repository는 UserService만 관리하게 하려고 도메인을 user와 auth로 나눔



## 📸 스크린샷

### 회원가입
access token 출력
<img width="837" alt="Pasted Graphic 1" src="https://github.com/user-attachments/assets/62833073-fcfc-4e51-9e19-26b4891fd5fa" />

refresh token (쿠키사용)
<img width="851" alt="Pasted Graphic 2" src="https://github.com/user-attachments/assets/61a79a2a-cec8-4975-ab71-1a26e9024644" />

유효성 검사시 여러개 에러 출력
<img width="840" alt="Pasted Graphic 6" src="https://github.com/user-attachments/assets/843d157c-12ed-4f41-b302-cb2d47e64853" />


### 로그인
<img width="831" alt="Pasted Graphic 4" src="https://github.com/user-attachments/assets/cd869698-5a3a-4063-bcc8-1b3f904fd094" />

### 토큰 재발급(token rotation)
<img width="848" alt="Pasted Graphic 5" src="https://github.com/user-attachments/assets/26a03ea7-d170-4b51-aa04-8abba3a2052a" />





