### PR TITLE
[fix] 권한 없을시 403에러로 응답

### DIFF
--- a/src/main/java/com/example/eightyage/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/eightyage/domain/auth/controller/AuthController.java
@@ -10,7 +10,11 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.annotation.Secured;
 import org.springframework.web.bind.annotation.*;
+
+import static com.example.eightyage.domain.user.entity.UserRole.Authority.ADMIN;
+import static com.example.eightyage.domain.user.entity.UserRole.Authority.USER;
 
 @RestController
 @RequiredArgsConstructor
@@ -47,6 +51,7 @@ public class AuthController {
     }
 
     /* 토큰 재발급 (로그인 기간 연장) */
+    @Secured({USER, ADMIN})
     @GetMapping("/v1/auth/refresh")
     public AuthAccessTokenResponseDto refresh(
             @RefreshToken String refreshToken,

--- a/src/main/java/com/example/eightyage/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/eightyage/global/exception/GlobalExceptionHandler.java
@@ -1,10 +1,10 @@
 package com.example.eightyage.global.exception;
 
-import com.example.eightyage.domain.product.entity.Product;
 import com.example.eightyage.global.entity.ErrorResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import java.util.List;
 
+import static com.example.eightyage.global.exception.ErrorMessage.DEFAULT_FORBIDDEN;
 import static com.example.eightyage.global.exception.ErrorMessage.INTERNAL_SERVER_ERROR;
 
 @Slf4j
@@ -34,6 +35,12 @@ public class GlobalExceptionHandler {
                 .map(error -> error.getField() + ": " + error.getDefaultMessage())
                 .toList();
         return ErrorResponse.of(HttpStatus.BAD_REQUEST, validFailedList);
+    }
+
+    @ResponseStatus(value = HttpStatus.FORBIDDEN)
+    @ExceptionHandler(AccessDeniedException.class)
+    public ErrorResponse<String> handleAccessDeniedException() {
+        return ErrorResponse.of(HttpStatus.FORBIDDEN, DEFAULT_FORBIDDEN.getMessage());
     }
 
     @ResponseStatus(value = HttpStatus.INTERNAL_SERVER_ERROR)


### PR DESCRIPTION
## 🔗 Issue Number
close #20 

## 📝 작업 내역
### 개선한 것
- [X] 로그인을 했다면 refresh 토큰 재발급 가능
- [X] 권한이 없는 유저가 접근했을 때 500에러가 발생한 것을 403에러가 출력되도록 GlobalExceptionHandler 수정


## 💡 PR 특이사항
<!--- PR을 볼 때 팀원에게 알려야 할 특이사항, 논의해야할 부분 등을 알려주세요.-->

