### PR TITLE
[feat] sorted set 구조를 이용한 실시간 인기 검색어 조회 기능 구현

### DIFF
--- a/src/main/java/com/example/eightyage/domain/product/controller/ProductController.java
+++ b/src/main/java/com/example/eightyage/domain/product/controller/ProductController.java
@@ -74,6 +74,17 @@ public class ProductController {
         return ResponseEntity.ok(productService.getProductsV2(name, category, size, page));
     }
 
+    // 제품 다건 조회 version 3
+    @GetMapping("/v3/products")
+    public ResponseEntity<Page<ProductSearchResponseDto>> searchProductV3(
+            @RequestParam(required = false) String name,
+            @RequestParam(required = false) Category category,
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(defaultValue = "1") int page
+    ) {
+        return ResponseEntity.ok(productService.getProductsV3(name, category, size, page));
+    }
+
     // 제품 삭제
     @Secured("ROLE_ADMIN")
     @DeleteMapping("/v1/products/{productId}")

--- a/src/main/java/com/example/eightyage/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/example/eightyage/domain/product/repository/ProductRepository.java
@@ -19,7 +19,7 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
     Optional<Product> findById(@Param("productId") Long productId);
 
     @Query("SELECT new com.example.eightyage.domain.product.dto.response.ProductSearchResponseDto(p.name, p.category, p.price, AVG(r.score)) " +
-            "FROM Product p JOIN p.reviews r " +
+            "FROM Product p LEFT JOIN p.reviews r " +
             "WHERE p.saleState = 'FOR_SALE' " +
             "AND (:category IS NULL OR p.category = :category) " +
             "AND (:name IS NULL OR p.name LIKE CONCAT('%', :name, '%')) " +

--- a/src/main/java/com/example/eightyage/domain/search/controller/SearchController.java
+++ b/src/main/java/com/example/eightyage/domain/search/controller/SearchController.java
@@ -3,6 +3,7 @@ package com.example.eightyage.domain.search.controller;
 import com.example.eightyage.domain.search.dto.PopularKeywordDto;
 import com.example.eightyage.domain.search.service.v1.PopularKeywordServiceV1;
 import com.example.eightyage.domain.search.service.v2.PopularKeywordServiceV2;
+import com.example.eightyage.domain.search.service.v3.PopularKeywordServiceV3;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -17,6 +18,7 @@ public class SearchController {
 
     private final PopularKeywordServiceV1 popularKeywordServiceV1;
     private final PopularKeywordServiceV2 popularKeywordServiceV2;
+    private final PopularKeywordServiceV3 popularKeywordServiceV3;
 
     // 인기 검색어 조회 (캐시 X)
     @GetMapping("/api/v1/search/popular")
@@ -32,5 +34,13 @@ public class SearchController {
             @RequestParam(defaultValue = "7") int days
     ) {
         return ResponseEntity.ok(popularKeywordServiceV2.searchPopularKeywords(days));
+    }
+
+    // 실시간 인기 검색어 조회 (캐시 O)
+    @GetMapping("/api/v3/search/popular")
+    public ResponseEntity<List<PopularKeywordDto>> searchPopularKeywordsV3(
+            @RequestParam(defaultValue = "10") int limits
+    ) {
+        return ResponseEntity.ok(popularKeywordServiceV3.searchPopularKeywords(limits));
     }
 }

--- a/src/main/java/com/example/eightyage/domain/search/dto/PopularKeywordDto.java
+++ b/src/main/java/com/example/eightyage/domain/search/dto/PopularKeywordDto.java
@@ -14,4 +14,7 @@ public class PopularKeywordDto {
     private String keyword;
     private Long count;
 
+    public static PopularKeywordDto of(String keyword, Long score) {
+        return new PopularKeywordDto(keyword, score);
+    }
 }

--- a/src/main/java/com/example/eightyage/domain/search/service/v2/KeywordCountFlushService.java
+++ b/src/main/java/com/example/eightyage/domain/search/service/v2/KeywordCountFlushService.java
@@ -1,4 +1,4 @@
-package com.example.eightyage.domain.search.service;
+package com.example.eightyage.domain.search.service.v2;
 
 import com.example.eightyage.domain.search.entity.KeywordCount;
 import com.example.eightyage.domain.search.repository.KeywordCountRepository;

--- a/src/main/java/com/example/eightyage/domain/search/service/v2/SearchServiceV2.java
+++ b/src/main/java/com/example/eightyage/domain/search/service/v2/SearchServiceV2.java
@@ -47,6 +47,7 @@ public class SearchServiceV2 {
         updateKeywordSet(keyword);
     }
 
+    // 캐시에 키워드 추가
     private void updateKeywordSet(String keyword) {
         Cache keySetCache = cacheManager.getCache(KEYWORD_KEY_SET);
         if (keySetCache != null) {

--- a/src/main/java/com/example/eightyage/domain/search/service/v3/PopularKeywordServiceV3.java
+++ b/src/main/java/com/example/eightyage/domain/search/service/v3/PopularKeywordServiceV3.java
@@ -1,0 +1,34 @@
+package com.example.eightyage.domain.search.service.v3;
+
+import com.example.eightyage.domain.search.dto.PopularKeywordDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class PopularKeywordServiceV3 {
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private static final String RANKING_KEY = "rankingPopularKeywords";
+
+    // 인기 검색어 상위 N개 조회
+    @Transactional(readOnly = true)
+    public List<PopularKeywordDto> searchPopularKeywords(int limit) {
+        Set<ZSetOperations.TypedTuple<String>> keywordSet =
+                redisTemplate.opsForZSet().reverseRangeWithScores(RANKING_KEY, 0, limit - 1);
+
+        if (keywordSet == null) {
+            return List.of();
+        }
+        return keywordSet.stream().map(tuple -> PopularKeywordDto.of(tuple.getValue(), Objects.requireNonNull(tuple.getScore()).longValue()))
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/example/eightyage/domain/search/service/v3/SearchServiceV3.java
+++ b/src/main/java/com/example/eightyage/domain/search/service/v3/SearchServiceV3.java
@@ -1,0 +1,36 @@
+package com.example.eightyage.domain.search.service.v3;
+
+import com.example.eightyage.domain.search.entity.SearchLog;
+import com.example.eightyage.domain.search.repository.SearchLogRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import java.time.Duration;
+
+
+@Service
+@RequiredArgsConstructor
+public class SearchServiceV3 {
+
+    private final SearchLogRepository searchLogRepository;
+    private final RedisTemplate<String, String> redisTemplate;
+    private static final String RANKING_KEY = "rankingPopularKeywords";
+
+    // 검색 키워드를 로그에 저장
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void saveSearchLog(String keyword) {
+        if (StringUtils.hasText(keyword)) {
+            searchLogRepository.save(SearchLog.of(keyword));
+        }
+    }
+
+    // 검색어 점수 증가
+    public void increaseSortedKeywordRank(String productName) {
+        redisTemplate.opsForZSet().incrementScore(RANKING_KEY, productName, 1);
+        redisTemplate.expire(RANKING_KEY, Duration.ofMinutes(1));
+    }
+}


### PR DESCRIPTION
## 🔗 Issue Number
<!--- close #이슈번호 -->
close #31

## 📝 작업 내역
<!--- 구현 내용 및 변경 사항, 관련 이슈에 대해 간단하게 작성해주세요.-->
- [X] Redis Sorted Set을 통한 검색어 저장 및 score 증가 기능 구현
- [X] 실시간 인기 검색어 조회 API(v3) 구현 (GET /api/v3/search/popular)

## 💡 PR 특이사항
<!--- PR을 볼 때 팀원에게 알려야 할 특이사항, 논의해야할 부분 등을 알려주세요.-->
전체 제품 검색하는 api 생성 (`api/v3/products`)
실시간 인기 검색어를 조회하는 api 생성 (`api/v3/search/popular`)
리뷰 없는 제품은 조회 되지 않아서, JOIN 에서 LEFT JOIN으로 쿼리 수정하였습니다.

## 📸 스크린샷

<img width="746" alt="image" src="https://github.com/user-attachments/assets/f5c2eedb-06e8-4d81-aaec-4e9e1c891550" />

<img width="1999" alt="스크린샷 2025-03-28 17 05 10" src="https://github.com/user-attachments/assets/e6f29e7d-715a-406d-8c26-801f6eff216d" />

